### PR TITLE
Hook support

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,40 @@ shArgs.arg is the method used to register commnd line parameters or flags.
 | long name | the long version command line flag and should start with two dashes | --messages
 |type| either PARAMETER (for inputs with values) or FLAG (for boolean inputs which do not require a value) | -d
 |auto export| either true or false . If true, then the key is exported to the global scope as a variable with the input value.| true
+|hook method name| Name of a method to invoke when the argument is found (see hooks section below)| "hookMethod"
+
+## Hook methods
+
+shArg support hook functions, which are bash functions that get invoked when the parse method finds an input that matches an argument. Hook method binding are useful for setting other values or side effects when an input is found.
+
+examle:
+
+```shell
+
+source ../scripts/shArg.sh
+
+declare AZURE_DEVOPS_ORG
+declare AZURE_DEVOPS_URL
+
+orgHook() {
+  local org=$1
+
+  # Build url from bound value
+  AZURE_DEVOPS_URL="https://dev.azure.com/$org"
+
+  echo "Azure DevOps Url      : $AZURE_DEVOPS_URL"
+  echo "Azure DevOps Org Name : $AZURE_DEVOPS_ORG"
+
+}
+
+# register arguments
+shArgs.arg "AZURE_DEVOPS_ORG" -o --orgName PARAMETER true orgHook
+
+# parse inputs
+shArgs.parse $@
+
+
+```
 
 ## Running the tests
 

--- a/examples/hook.sh
+++ b/examples/hook.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+# #########################################################
+# Navigate to the examples folder and invoke this file.
+# cd examples
+# ./simple_example.sh -m hello -d
+# #########################################################
+
+# load shArg
+source ../scripts/shArg.sh
+
+declare MESSAGE
+
+# Declare a hook method to fire when the message argument is found
+# Hook methods allow you to run a piece of code for additional behaviors when an argument is bound
+messageHook() {
+  local message=$1
+
+  echo "message hooked invoked with $message"
+  echo "Global variable is still available $MESSAGE"
+
+}
+
+# register arguments
+shArgs.arg "MESSAGE" -m --message PARAMETER true messageHook
+
+# parse inputs
+shArgs.parse $@
+
+

--- a/scripts/shArg.sh
+++ b/scripts/shArg.sh
@@ -4,14 +4,14 @@ declare -A _SH_ARGUMENTS=()
 declare -A _SH_SWITCHES=()
 declare -A _SH_TYPES=()
 declare -A _SH_AUTOS=()
-
+declare -A _SH_HOOK_FUNCTIONS=()
 shArgs.arg(){   
     local variableName=$1
     local shortName=$2
     local longName=$3
     local argType=$4
     local auto=$5
-
+    local hookFunction=$6
     if [ ! -z "$shortName" ]; then
         _SH_SWITCHES[$shortName]=$variableName
     fi
@@ -37,6 +37,10 @@ shArgs.arg(){
     else
         _SH_AUTOS[$variableName]=false
     fi
+
+    if [ ! -z "$hookFunction" ]; then
+        _SH_HOOK_FUNCTIONS[$variableName]=$hookFunction
+    fi
 }
 
 shArgs.parse(){
@@ -52,6 +56,7 @@ shArgs.parse(){
                 if [ ! -z "$_varName" ]; then
                     argType=${_SH_TYPES[$_varName]}
                     autoExport=${_SH_AUTOS[$_varName]}
+                    hookFunction=${_SH_HOOK_FUNCTIONS[$_varName]}
                     if [ "$argType" == "FLAG" ]; then
                         _SH_ARGUMENTS[$_varName]=true
                         if [ "$autoExport" == true ]; then
@@ -64,6 +69,9 @@ shArgs.parse(){
                         fi
                         shift
                     fi
+                    if [ ! -z "$hookFunction" ]; then          
+                        eval "$hookFunction \"${_SH_ARGUMENTS[$_varName]}\""                    
+                    fi                    
                 fi                
                 ;; 
         esac

--- a/spec/shArg_spec.sh
+++ b/spec/shArg_spec.sh
@@ -143,7 +143,12 @@ Describe 'shArg'
       When call shArgs.parse -l http://fake.com 
       The value "$URL_HOOK_VALUE" should equal "http://fake.com"
     End 
-    
+
+    It 'should not call a hook method when the bound argument is not passed in #7'
+      When call shArgs.parse --message "test123"
+      The value "$URL_HOOK_CALLED" should equal false
+    End 
+
   End 
 
   Context "val helper method"

--- a/spec/shArg_spec.sh
+++ b/spec/shArg_spec.sh
@@ -67,13 +67,20 @@ Describe 'shArg'
   End
 
   Context "Argument Parsing"
+    urlHook(){
+      URL_HOOK_CALLED=true
+      URL_HOOK_VALUE=$1
+    }
+
     setup() { 
       # argument registration used by the specs that follow.
-      shArgs.arg "MESSAGE" -m --message PARAMETER   #1
-      shArgs.arg "DEBUG" -d --debug FLAG            #2
-      shArgs.arg "USER" -u                          #3
-      shArgs.arg "OUTPUT" --output                  #4
-      shArgs.arg "FILE" -f --file PARAMETER true    #5
+      shArgs.arg "MESSAGE" -m --message PARAMETER       #1
+      shArgs.arg "DEBUG" -d --debug FLAG                #2
+      shArgs.arg "USER" -u                              #3
+      shArgs.arg "OUTPUT" --output                      #4
+      shArgs.arg "FILE" -f --file PARAMETER true        #5
+      shArgs.arg "URL" -l --url PARAMETER true urlHook  #6
+      URL_HOOK_CALLED=false
     }
     BeforeEach 'setup'
 
@@ -126,6 +133,17 @@ Describe 'shArg'
       The value "${_SH_ARGUMENTS['FILE']}" should equal "input.dat"
       The value "$FILE" should equal "input.dat" 
     End
+
+    It 'should call a hook method when a binding occurs #7'
+      When call shArgs.parse --message "test123" -u bob --output table --file test1.txt -l http://fake.com -d
+      The value "$URL_HOOK_CALLED" should equal true
+    End 
+
+    It 'should call a hook method with input parameter when a binding occurs #8'
+      When call shArgs.parse -l http://fake.com 
+      The value "$URL_HOOK_VALUE" should equal "http://fake.com"
+    End 
+    
   End 
 
   Context "val helper method"


### PR DESCRIPTION
This PR adds support for hook methods.

Hook methods allow scripts to intercept the binding of arguments and add additional behavior when an argument is passed into the script and bound.

Note hook methods only fire when the parameter is passed in. Hook methods do not fire if the argument that the hook method is bound to is not assigned via the command line.