### PR TITLE
added support for csv input to array

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,67 @@ fi
     * using the _SH_ARGUMENTS array
       ``` echo "MESSAGE = ${_SH_ARGUMENTS["MESSAGE"]}" ```
 
+## Parameter Types
+
+shArg has two main input types; PARAMETER and FLAG. 
+
+* PARAMETER:
+
+  A parameter is defined as an input that has an associated value.
+
+  For example: 
+
+  ```shell
+  # arg
+  shArgs.arg "MESSAGE" -m --message PARAMETER true
+
+  # invoke with
+  ./myscript.sh --message "hello world"
+  ```
+
+  hello world is the value specified for the message parameter.
+
+  Parameters can be a single value or a comma separated value (csv.) You can pass a csv in and it will be automatically converted to a bash array.
+
+  ```shell
+  #arg 
+  shArgs.arg "IPS" -i --ips PARAMETER true 
+
+  # invoke with
+  ./list.sh -i 1.1.1.1,2.2.2.2
+  ```
+
+  ***Note:*** For csv inputs, please ensure that there is no space between elements and associated commas. This applies event with quotes inputs.
+
+  ```shell
+  # This will work
+  ./list.sh -i 1.1.1.1,2.2.2.2
+
+  # This will not work
+  ./list.sh -i 1.1.1.1, 2.2.2.2
+
+  # This will not work, even with quotes
+  ./list.sh -i "1.1.1.1, 2.2.2.2"
+  ```
+
+* FLAG:
+  shArg also supports FLAG, which is a boolean input that does not require a value.
+
+  For example: 
+
+  ```shell
+  # arg 
+  shArgs.arg "DEBUG" -d --debug FLAG true
+
+  # invoke with
+  ./myscript.sh --debug
+  ```
+
+  In this case including --debug when calling the script will set the DEBUG variable to true. Omitting it, sets DEBUG to false. There isn't a need to pass a value after debug.
+
+
+
+
 ## shArgs.arg reference
 shArgs.arg is the method used to register commnd line parameters or flags.
 

--- a/examples/list.sh
+++ b/examples/list.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+# #########################################################
+# Navigate to the examples folder and invoke this file.
+# cd examples
+# ./list.sh -i 1.1.1.1,2.2.2.2
+# #########################################################
+
+# load shArg
+source ../scripts/shArg.sh
+
+declare IPS
+
+# register arguments
+shArgs.arg "IPS" -i --ips PARAMETER true 
+
+# parse inputs
+shArgs.parse $@
+
+for ip in $IPS
+do
+    echo "ip: $ip"
+done
+
+# Expected Output
+# $ ./list.sh -i 1.1.1.1,2.2.2.2
+# ip: 1.1.1.1
+# ip: 2.2.2.2

--- a/scripts/shArg.sh
+++ b/scripts/shArg.sh
@@ -52,7 +52,7 @@ shArgs.parse(){
         case $1 in
             *)   
                 _varName=${_SH_SWITCHES[$1]}      
-         
+                
                 if [ ! -z "$_varName" ]; then
                     argType=${_SH_TYPES[$_varName]}
                     autoExport=${_SH_AUTOS[$_varName]}
@@ -63,17 +63,27 @@ shArgs.parse(){
                             eval "$_varName=true"
                         fi
                     else
-                        _SH_ARGUMENTS[$_varName]=$2
-                        if [ "$autoExport" == true ]; then
-                            eval "$_varName=$2"
+                        local _varValue=""
+                        if [[ "$2" == *","* ]]; then
+                            local _listInput=$2
+                            local arr
+                            IFS=, read -a arr <<<"${_listInput}"
+                            listData="${arr[@]}"
+                            _varValue=$listData
+                            _SH_ARGUMENTS[$_varName]="$listData"
+                        else
+                            _varValue=$2                             
                         fi
+                        _SH_ARGUMENTS[$_varName]=$_varValue
+                        if [ "$autoExport" == true ]; then
+                            eval "$_varName=\"$_varValue\""
+                        fi                                           
                         shift
                     fi
                     if [ ! -z "$hookFunction" ]; then          
                         eval "$hookFunction \"${_SH_ARGUMENTS[$_varName]}\""                    
                     fi                    
-                fi                
-                ;; 
+                fi      
         esac
         shift
     done

--- a/spec/shArg_spec.sh
+++ b/spec/shArg_spec.sh
@@ -172,6 +172,41 @@ Describe 'shArg'
       When call shArgs.val "INVALID"
       The output should equal ""
     End
-
   End 
+
+  Context "list inputs"
+    setup() { 
+      shArgs.arg "IPS" -i --ips PARAMETER true 
+    }
+    BeforeEach 'setup'
+
+    assert_val_method() {
+      local varName=$1
+      local expectedValue=$2
+      local value=$(shArgs.val "IPS")
+      if [ "$value" == "$expectedValue" ]; then
+        return 0
+      else
+        return 1
+      fi
+    }
+
+    assert_global_ips() {
+      local expectedValue=$1
+      if [ "$IPS" == "$expectedValue" ]; then
+        return 0
+      else
+        return 1
+      fi
+    }
+    It 'should return an array of ips when shArg.val is called'
+      When call shArgs.parse -i 10.10.10.1,10.10.10.2
+      Assert assert_val_method "IPS" "10.10.10.1 10.10.10.2"
+    End
+
+    It 'should set the global variable IPS to an arra of ips'
+      When call shArgs.parse -i 10.10.10.1,10.10.10.2
+      Assert assert_global_ips  "10.10.10.1 10.10.10.2"
+    End
+  End   
 End


### PR DESCRIPTION
This change adds the ability to pass in a csv input that will be converted to a bash array.

Example:
```shell

./myscript -i 10.10.10.1,10.10.10.2

```

Note the input should contain spaces between elements and the comma.