### PR TITLE
Dash in value fix

### DIFF
--- a/scripts/shArg.sh
+++ b/scripts/shArg.sh
@@ -148,15 +148,21 @@ shArgs.parse(){
 
     for (( i=0; i<${#input_string}; i++ )); do
         char=${input_string:$i:1}    
+
         if [ "$char" == "-" ]; then
-          if [ ! -z "$tmp" ]; then
-            _processLine "$tmp"
-            tmp=""
-          fi
-          if [ "${input_string:$i:2}" == "--" ]; then
-            tmp+="$char"
-            i=$((i+1))
-          fi
+            if [ "$i" > "0" ]; then
+                char2=${input_string:$i-1:1}   
+                if [ "$char2" == " " ]; then
+                    if [ ! -z "$tmp" ]; then
+                        _processLine "$tmp"
+                        tmp=""
+                    fi
+                    if [ "${input_string:$i:2}" == "--" ]; then
+                        tmp+="$char"
+                        i=$((i+1))
+                    fi
+                fi
+            fi        
         fi
         tmp+="$char"
     done   

--- a/scripts/shArg.sh
+++ b/scripts/shArg.sh
@@ -150,7 +150,7 @@ shArgs.parse(){
         char=${input_string:$i:1}    
 
         if [ "$char" == "-" ]; then
-            if [ "$i" > "0" ]; then
+            if [ "$i" -gt "0"  ]; then
                 char2=${input_string:$i-1:1}   
                 if [ "$char2" == " " ]; then
                     if [ ! -z "$tmp" ]; then

--- a/scripts/shArg.sh
+++ b/scripts/shArg.sh
@@ -145,14 +145,15 @@ shArgs.parse(){
     local input_string=$@
     local char=""
     local tmp=""
-
+    local previousChar=""
+    
     for (( i=0; i<${#input_string}; i++ )); do
         char=${input_string:$i:1}    
 
         if [ "$char" == "-" ]; then
             if [ "$i" -gt "0"  ]; then
-                char2=${input_string:$i-1:1}   
-                if [ "$char2" == " " ]; then
+                previousChar=${input_string:$i-1:1}   
+                if [ "$previousChar" == " " ]; then
                     if [ ! -z "$tmp" ]; then
                         _processLine "$tmp"
                         tmp=""

--- a/spec/unit/edge_cases_spec.sh
+++ b/spec/unit/edge_cases_spec.sh
@@ -1,0 +1,17 @@
+ 
+Describe 'shArg'
+  Include scripts/shArg.sh
+
+  Context "Argument Parsing"
+    setup() { 
+      # argument registration used by the specs that follow.
+      shArgs.arg "RESOURCE_GROUP" -g --resource PARAMETER true
+    }
+    BeforeEach 'setup'
+
+    It 'should parse an argument value with dashes in the text'
+      When call shArgs.parse -g "my-test-group"
+      The value "$RESOURCE_GROUP" should equal "my-test-group"
+    End
+  End 
+End


### PR DESCRIPTION
This change introduces the capability to have dashes in parameter values.

For example : `./myscript.sh --resource-group test-group`

This adds a fix to allow for dashes in values, as long as it's not the start of a word.  This does not work `./myscript.sh --resource-group -test-group`